### PR TITLE
Fix default index html for old browsers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
         // Remove `false` to enable sw
         if (false && 'serviceWorker' in navigator) {
             // Use the window load event to keep the page load performant
-            window.addEventListener('load', () => {
+            window.addEventListener('load', function() {
                 navigator.serviceWorker.register('/sw.js')
             });
         }


### PR DESCRIPTION
Fix default index html for browsers that are not supporting arrow functions